### PR TITLE
Allow snippets to exist without being on the canvas

### DIFF
--- a/src/Editor.tsx
+++ b/src/Editor.tsx
@@ -11,6 +11,7 @@ import {
   SpatialComponentType,
   textEditorStateMobx,
 } from "./primitives";
+import { getSnippetForSnippetOnCanvas } from "./utils";
 
 const textIdFacet = Facet.define<string, string>({
   combine: (values) => values[0],
@@ -131,10 +132,11 @@ export function Editor({ textId }: { textId: string }) {
           for (const spatialComponent of spatialComponentsMobx) {
             switch (spatialComponent.spatialComponentType) {
               case SpatialComponentType.Snippet: {
-                if (spatialComponent.textId === textId) {
-                  spatialComponent.span = [
-                    transaction.changes.mapPos(spatialComponent.span[0]),
-                    transaction.changes.mapPos(spatialComponent.span[1]),
+                const snippet = getSnippetForSnippetOnCanvas(spatialComponent);
+                if (snippet.textId === textId) {
+                  snippet.span = [
+                    transaction.changes.mapPos(snippet.span[0]),
+                    transaction.changes.mapPos(snippet.span[1]),
                   ];
                 }
                 break;

--- a/src/primitives.ts
+++ b/src/primitives.ts
@@ -25,14 +25,13 @@ Serve in bowl and garnish to taste with grated cheddar, avocado, sour cream, jal
 `;
 
 export const INGREDIENT_TYPE = "ingredient";
-const DEFAULT_SNIPPET_TYPES: SnippetType[] = [
-  {
-    id: INGREDIENT_TYPE,
+const DEFAULT_SNIPPET_TYPES: { [key: string]: SnippetType } = {
+  [INGREDIENT_TYPE]: {
     name: "Ingredient",
     icon: "🥕",
     color: "#ffc107",
   },
-];
+};
 
 const FIRST_TEXT_ID = "text-id-1";
 export const textEditorStateMobx = observable.map<string, EditorState>(
@@ -55,24 +54,27 @@ export enum SpatialComponentType {
 }
 
 export type SnippetType = {
-  id: string;
   name: string;
   icon: string;
   color: string;
 };
 
 export type Snippet = {
-  spatialComponentType: SpatialComponentType.Snippet;
-
   id: string;
   snippetTypeId: string;
   textId: string;
   span: Span;
-  position: Position;
-
   /** { [columnId]: data } */
   data: { [key: string]: any };
 };
+
+export type SnippetOnCanvas = {
+  spatialComponentType: SpatialComponentType.Snippet;
+  id: string;
+  snippetId: string;
+  position: Position;
+};
+
 export type SnippetGroup = {
   spatialComponentType: SpatialComponentType.SnippetGroup;
   id: string;
@@ -102,13 +104,17 @@ window.exampleSetSnippetSuggestion = (
   });
 };
 
-export type SpatialComponent = Snippet | SnippetGroup;
+export type SpatialComponent = SnippetOnCanvas | SnippetGroup;
 export const getGroupWidth = (group: SnippetGroup): number => {
   return (group.extraColumns.length + 1) * GROUP_COLUMN_WIDTH;
 };
 
+export const snippetTypesMobx = observable.map<string, SnippetType>(
+  DEFAULT_SNIPPET_TYPES
+);
+export const snippetsMobx = observable.map<string, Snippet>({});
+
 export const spatialComponentsMobx = observable<SpatialComponent>([]);
-export const snippetTypesMobx = observable<SnippetType>(DEFAULT_SNIPPET_TYPES);
 export const selectedSpatialComponentsMobx = observable<string>([]);
 
 export type DragState = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,8 +6,10 @@ import {
   TOKEN_HEIGHT,
   Position,
   CHAR_WIDTH,
-  Snippet,
+  SnippetOnCanvas,
   textEditorStateMobx,
+  snippetsMobx,
+  Snippet,
 } from "./primitives";
 
 // your favorite dumping ground of utility functions
@@ -33,13 +35,14 @@ export function getRectForSnippetGroup(group: SnippetGroup): Rect {
   ];
 }
 
-export function getRectForSnippetToken(snippet: Snippet): Rect {
+export function getRectForSnippetToken(snippetOnCanvas: SnippetOnCanvas): Rect {
+  const snippet = getSnippetForSnippetOnCanvas(snippetOnCanvas);
   const text = textEditorStateMobx
     .get(snippet.textId)!
     .sliceDoc(snippet.span[0], snippet.span[1]);
   return [
-    snippet.position[0],
-    snippet.position[1],
+    snippetOnCanvas.position[0],
+    snippetOnCanvas.position[1],
     text.length * CHAR_WIDTH + 16,
     TOKEN_HEIGHT,
   ];
@@ -53,4 +56,10 @@ export function getPositionForSnippetInGroup(
     group.position[0],
     group.position[1] + index * (TOKEN_HEIGHT + GROUP_TOKEN_ROW_GAP),
   ];
+}
+
+export function getSnippetForSnippetOnCanvas(
+  snippetOnCanvas: SnippetOnCanvas
+): Snippet {
+  return snippetsMobx.get(snippetOnCanvas.snippetId)!;
 }


### PR DESCRIPTION
Separates out Snippet and SnippetOnCanvas.
A Snippet references the text and has some associated data.
A SnippetOnCanvas references a Snippet and has a position.

This allows things like:
- Automatically creating snippets without needing to bring onto the canvas
- Having multiple tokens on the canvas that refer to the same snippet of text